### PR TITLE
Increased decimal conversion precision to 3

### DIFF
--- a/nice_nano_pretty.js
+++ b/nice_nano_pretty.js
@@ -150,7 +150,7 @@ module.exports =  {
           nx = (cos * (adj_x - at_x)) + (sin * (adj_y - at_y)) + at_x,
           ny = (cos * (adj_y - at_y)) - (sin * (adj_x - at_x)) + at_y;
 
-        const point_str = `${nx.toFixed(2)} ${ny.toFixed(2)}`;
+        const point_str = `${nx.toFixed(3)} ${ny.toFixed(3)}`;
         return point_str;
       }
 


### PR DESCRIPTION
When precision is set to 2, traces are approximated to locations that may not match what KiCad would create. This generates a few warnings in the Freerouting software when autorouting:

```
--FRCLI--WARN--FloatLine: Parameter is null
```

Increasing the number conversion precision resolves the warning.